### PR TITLE
Migration max input length error fixed for Wamp server

### DIFF
--- a/BackEnd/app/Providers/AppServiceProvider.php
+++ b/BackEnd/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Schema::defaultStringLength(191);
     }
 }

--- a/BackEnd/database/migrations/2023_08_21_185356_create_customers_table.php
+++ b/BackEnd/database/migrations/2023_08_21_185356_create_customers_table.php
@@ -22,11 +22,10 @@ return new class extends Migration {
             $table->boolean('active');
             $table->string('connection_date')->nullable();
             $table->string('bill_genarate_status')->nullable();
-            $table->string('note')->nullable();
+            $table->text('note')->nullable();
             $table->string('bill_collector')->nullable();
             $table->integer('number_of_connection')->nullable()->default(1);
             $table->timestamps();
-
         });
     }
 

--- a/BackEnd/database/migrations/2023_08_22_191400_create_customer_histories_table.php
+++ b/BackEnd/database/migrations/2023_08_22_191400_create_customer_histories_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->foreignId('user_id')->constrained(
                 'users', 'id'
             );
-            $table->string('description')->nullable();
+            $table->text('description')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
There was some problem with Wampserver mysql 8.0.31. 

When I was running `php artisan migrate:fresh --seed` it showed me a max string length error for long text columns like the description. There was `$table->string('note');` but it should be  `$table->text('note');`


It's fixed now. We can test and merge to the main branch if all ok.